### PR TITLE
Feature/array column

### DIFF
--- a/column.go
+++ b/column.go
@@ -36,20 +36,7 @@ SELECT table_schema
     , is_identity
     , identity_generation
 	, substring(udt_name from 2) AS array_type
-	, attndims AS array_dimensions
 FROM information_schema.columns
-JOIN (SELECT attname
-		, attndims
-		, relname
-		, nspname
-	FROM pg_attribute
-	JOIN pg_class
-	ON attrelid = pg_class.oid
-	JOIN pg_namespace
-	ON pg_class.relnamespace = pg_namespace.oid) s
-ON (table_name = s.relname
-	AND column_name = s.attname
-	AND table_schema = s.nspname)
 WHERE is_updatable = 'YES'
 {{if eq $.DbSchema "*" }}
 AND table_schema NOT LIKE 'pg_%' 
@@ -151,9 +138,7 @@ func (c *ColumnSchema) Add() {
 			//fmt.Println("-- Note that adding of array data types are not yet generated properly.")
 		//}
 		if dataType == "ARRAY" {
-			dimensions, err := strconv.Atoi(c.get("array_dimensions"))
-			check("converting string to int", err)
-			dataType = getArrayDefinition(c.get("array_type"), dimensions)
+			dataType = c.get("array_type")+"[]"
 		}
 		//fmt.Printf("ALTER TABLE %s.%s ADD COLUMN %s %s", schema, c.get("table_name"), c.get("column_name"), c.get("data_type"))
 		fmt.Printf("ALTER TABLE %s.%s ADD COLUMN %s %s", schema, c.get("table_name"), c.get("column_name"), dataType)
@@ -186,10 +171,20 @@ func (c *ColumnSchema) Change(obj interface{}) {
 		fmt.Println("Error!!!, ColumnSchema.Change(obj) needs a ColumnSchema instance", c2)
 	}
 
+	// Adjust data type for array columns
+	dataType1 := c.get("data_type")
+	if dataType1 == "ARRAY" {
+		dataType1 = c.get("array_type")+"[]"
+	}
+	dataType2 := c2.get("data_type")
+	if dataType2 == "ARRAY" {
+		dataType2 = c2.get("array_type")+"[]"
+	}
+
 	// Detect column type change (mostly varchar length, or number size increase)
 	// (integer to/from bigint is OK)
-	if c.get("data_type") == c2.get("data_type") {
-		if c.get("data_type") == "character varying" {
+	if dataType1 != dataType2 {
+		if dataType1 == "character varying" {
 			max1, max1Valid := getMaxLength(c.get("character_maximum_length"))
 			max2, max2Valid := getMaxLength(c2.get("character_maximum_length"))
 			if !max1Valid && !max2Valid {
@@ -212,16 +207,16 @@ func (c *ColumnSchema) Change(obj interface{}) {
 	}
 
 	// Code and test a column change from integer to bigint
-	if c.get("data_type") != c2.get("data_type") {
-		fmt.Printf("-- WARNING: This type change may not work well: (%s to %s).\n", c2.get("data_type"), c.get("data_type"))
-		if strings.HasPrefix(c.get("data_type"), "character") {
+	if dataType1 != dataType2 {
+		fmt.Printf("-- WARNING: This type change may not work well: (%s to %s).\n", dataType2, dataType1)
+		if strings.HasPrefix(dataType1, "character") {
 			max1, max1Valid := getMaxLength(c.get("character_maximum_length"))
 			if !max1Valid {
 				fmt.Println("-- WARNING: varchar column has no maximum length.  Setting to 1024")
 			}
-			fmt.Printf("ALTER TABLE %s.%s ALTER COLUMN %s TYPE %s(%s);\n", c2.get("table_schema"), c.get("table_name"), c.get("column_name"), c.get("data_type"), max1)
+			fmt.Printf("ALTER TABLE %s.%s ALTER COLUMN %s TYPE %s(%s);\n", c2.get("table_schema"), c.get("table_name"), c.get("column_name"), dataType1, max1)
 		} else {
-			fmt.Printf("ALTER TABLE %s.%s ALTER COLUMN %s TYPE %s;\n", c2.get("table_schema"), c.get("table_name"), c.get("column_name"), c.get("data_type"))
+			fmt.Printf("ALTER TABLE %s.%s ALTER COLUMN %s TYPE %s;\n", c2.get("table_schema"), c.get("table_name"), c.get("column_name"), dataType1)
 		}
 	}
 

--- a/column.go
+++ b/column.go
@@ -312,6 +312,3 @@ func getMaxLength(maxLength string) (string, bool) {
 	return maxLength, true
 }
 
-func getArrayDefinition(arrayType string, dimensions int) string {
-	return arrayType + strings.Repeat("[]", dimensions)
-}

--- a/column.go
+++ b/column.go
@@ -35,7 +35,7 @@ SELECT table_schema
     , character_maximum_length
     , is_identity
     , identity_generation
-	, substring(udt_name from 2) AS array_type
+    , substring(udt_name from 2) AS array_type
 FROM information_schema.columns
 WHERE is_updatable = 'YES'
 {{if eq $.DbSchema "*" }}

--- a/column.go
+++ b/column.go
@@ -183,7 +183,7 @@ func (c *ColumnSchema) Change(obj interface{}) {
 
 	// Detect column type change (mostly varchar length, or number size increase)
 	// (integer to/from bigint is OK)
-	if dataType1 != dataType2 {
+	if dataType1 == dataType2 {
 		if dataType1 == "character varying" {
 			max1, max1Valid := getMaxLength(c.get("character_maximum_length"))
 			max2, max2Valid := getMaxLength(c2.get("character_maximum_length"))

--- a/test/test-column
+++ b/test/test-column
@@ -81,13 +81,13 @@ echo ==============================================================
     CREATE TABLE s3.table12 (
         ids integer[],
 		bigids bigint[],
-		something text[][]
+		something text[][] -- dimensions don't seem to matter, to ignore them
     );
 
 	CREATE SCHEMA s4;
-    CREATE TABLE s4.table12 (
-		bigids integer[],
-		something text
+    CREATE TABLE s4.table12 ( -- add ids column
+		bigids integer[], -- change bigids to int8[]
+		something text[] -- no change
 	);
 "
 
@@ -96,7 +96,6 @@ echo "# Compare array columns between two tables"
 echo "# Expect:"
 echo "#   Add s4.table12.ids int4[]"
 echo "#   Change s4.table12.bigids from to int8[]"
-echo "#   Change s4.table12.something to text[]"
 echo
 
 ../pgdiff -U "u1" -W "asdf" -H "localhost" -D "db1" -S "s3" -O "sslmode=disable" \

--- a/test/test-column
+++ b/test/test-column
@@ -81,7 +81,7 @@ echo ==============================================================
     CREATE TABLE s3.table12 (
         ids integer[],
 		bigids bigint[],
-		something text[][] -- dimensions don't seem to matter, to ignore them
+		something text[][] -- dimensions don't seem to matter, so ignore them
     );
 
 	CREATE SCHEMA s4;

--- a/test/test-column
+++ b/test/test-column
@@ -77,18 +77,17 @@ echo
 echo ==============================================================
 
 ./populate-db.sh db1 "
-	CREATE SCHEMA s3;
+    CREATE SCHEMA s3;
     CREATE TABLE s3.table12 (
         ids integer[],
-		bigids bigint[],
-		something text[][] -- dimensions don't seem to matter, so ignore them
+        bigids bigint[],
+        something text[][] -- dimensions don't seem to matter, so ignore them
     );
-
-	CREATE SCHEMA s4;
+    CREATE SCHEMA s4;
     CREATE TABLE s4.table12 ( -- add ids column
-		bigids integer[], -- change bigids to int8[]
-		something text[] -- no change
-	);
+        bigids integer[], -- change bigids to int8[]
+        something text[] -- no change
+    );
 "
 
 echo

--- a/test/test-column
+++ b/test/test-column
@@ -74,3 +74,32 @@ echo
           -u "u1" -w "asdf" -h "localhost" -d "db2" -s "*" -o "sslmode=disable" \
           COLUMN | grep -v '^-- '
 echo
+echo ==============================================================
+
+./populate-db.sh db1 "
+	CREATE SCHEMA s3;
+    CREATE TABLE s3.table12 (
+        ids integer[],
+		bigids bigint[],
+		something text[][]
+    );
+
+	CREATE SCHEMA s4;
+    CREATE TABLE s4.table12 (
+		bigids integer[],
+		something text
+	);
+"
+
+echo
+echo "# Compare array columns between two tables"
+echo "# Expect:"
+echo "#   Add s4.table12.ids int4[]"
+echo "#   Change s4.table12.bigids from to int8[]"
+echo "#   Change s4.table12.something to text[]"
+echo
+
+../pgdiff -U "u1" -W "asdf" -H "localhost" -D "db1" -S "s3" -O "sslmode=disable" \
+          -u "u1" -w "asdf" -h "localhost" -d "db1" -s "s4" -o "sslmode=disable" \
+          COLUMN | grep -v '^-- '
+echo


### PR DESCRIPTION
Support for array type columns. One oddity to note is that while PostgreSQL supports multi dimensional arrays, dimensions don't appear to be strictly enforced (or well, enforced at all).
```sql
-- For example, with table test,
CREATE TABLE test (
  a int[],
  b int[][][]
);

-- even though columns a and b have different dimensions, the following statement will succeed
INSERT INTO test (a, b) VALUES ('{{{1}, {2}}}'::int[], '{3}'::int[]);
```
So it's possible to check differences in dimensions while running the diff, but it doesn't seem to matter so I left it out. I can add it in if you'd like, though.