### PR TITLE
Do not diff internal triggers

### DIFF
--- a/function.go
+++ b/function.go
@@ -108,8 +108,6 @@ func (c *FunctionSchema) Compare(obj interface{}) int {
 
 // Add returns SQL to create the function
 func (c FunctionSchema) Add() {
-	fmt.Println("-- Add")
-
 	// If we are comparing two different schemas against each other, we need to do some
 	// modification of the first function definition so we create it in the right schema
 	functionDef := c.get("definition")
@@ -128,7 +126,6 @@ func (c FunctionSchema) Add() {
 
 // Drop returns SQL to drop the function
 func (c FunctionSchema) Drop() {
-	fmt.Println("-- Drop")
 	fmt.Println("-- Note that CASCADE in the statement below will also drop any triggers depending on this function.")
 	fmt.Println("-- Also, if there are two functions with this name, you will want to add arguments to identify the correct one to drop.")
 	fmt.Println("-- (See http://www.postgresql.org/docs/9.4/interactive/sql-dropfunction.html) ")
@@ -137,7 +134,6 @@ func (c FunctionSchema) Drop() {
 
 // Change handles the case where the function names match, but the definition does not
 func (c FunctionSchema) Change(obj interface{}) {
-	fmt.Println("-- Change")
 	c2, ok := obj.(*FunctionSchema)
 	if !ok {
 		fmt.Println("Error!!!, Change needs a FunctionSchema instance", c2)

--- a/grant_test.go
+++ b/grant_test.go
@@ -20,6 +20,6 @@ func doParseAcls(t *testing.T, acl string, expectedRole string, expectedPermCoun
 		t.Error("Wrong role parsed: " + role + " instead of " + expectedRole)
 	}
 	if len(perms) != expectedPermCount {
-		t.Error("Incorrect number of permissions parsed: %d instead of %d", len(perms), expectedPermCount)
+		t.Errorf("Incorrect number of permissions parsed: %d instead of %d", len(perms), expectedPermCount)
 	}
 }

--- a/pgdiff.go
+++ b/pgdiff.go
@@ -203,8 +203,7 @@ Options:
   -S, --schema1 : first schema.  default is all schemas
   -s, --schema2 : second schema. default is all schemas
 
-<schemaTpe> can be: SCHEMA ROLE, SEQUENCE, TABLE, VIEW, COLUMN, INDEX, FOREIGN_KEY, OWNER, GRANT_RELATIONSHIP, GRANT_ATTRIBUTE
-`)
+<schemaTpe> can be: ALL, SCHEMA, ROLE, SEQUENCE, TABLE, VIEW, COLUMN, INDEX, FOREIGN_KEY, OWNER, GRANT_RELATIONSHIP, GRANT_ATTRIBUTE, TRIGGER, FUNCTION`)
 
 	os.Exit(2)
 }

--- a/trigger.go
+++ b/trigger.go
@@ -33,7 +33,7 @@ func initTriggerSqlTemplate() *template.Template {
     FROM pg_catalog.pg_trigger t
     INNER JOIN pg_catalog.pg_class c ON (c.oid = t.tgrelid)
     INNER JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
-	WHERE true
+	WHERE not t.tgisinternal
     {{if eq $.DbSchema "*" }}
     AND n.nspname NOT LIKE 'pg_%' 
     AND n.nspname <> 'information_schema' 
@@ -106,8 +106,6 @@ func (c *TriggerSchema) Compare(obj interface{}) int {
 
 // Add returns SQL to create the trigger
 func (c TriggerSchema) Add() {
-	fmt.Println("-- Add")
-
 	// If we are comparing two different schemas against each other, we need to do some
 	// modification of the first trigger definition so we create it in the right schema
 	triggerDef := c.get("trigger_def")
@@ -131,7 +129,6 @@ func (c TriggerSchema) Drop() {
 
 // Change handles the case where the trigger names match, but the definition does not
 func (c TriggerSchema) Change(obj interface{}) {
-	fmt.Println("-- Change")
 	c2, ok := obj.(*TriggerSchema)
 	if !ok {
 		fmt.Println("Error!!!, Change needs a TriggerSchema instance", c2)


### PR DESCRIPTION
Diffing internal postgres triggers generates a lot of spurious output between two schemas that have the same logical structure but for which postgres has chosen different names. Alternatively we could make this a command line flag.

Also remove some superfluous output, in particular `pgdiff` currently reports `--Change` lines even if no change is emitted for functions and triggers.