### PR TITLE
Add a semicolon after the index definition to make the diff script va…

### DIFF
--- a/index.go
+++ b/index.go
@@ -152,7 +152,7 @@ func (c *IndexSchema) Add() {
 			-1)
 	}
 
-	fmt.Println(indexDef)
+	fmt.Printf("%v;\n", indexDef)
 
 	if c.get("constraint_def") != "null" {
 		// Create the constraint using the index we just created


### PR DESCRIPTION
…lid.

Without it the script fails to run using psql. Without it the script looks like this:
CREATE UNIQUE INDEX test123_pkey ON test123 USING btree (s1)
ALTER TABLE public.test123 ADD CONSTRAINT test123_pkey PRIMARY KEY USING INDEX test123_pkey; -- (1)

And the error looks like this:
psql:5-INDEX.sql:6: ERROR:  syntax error at or near "ALTER"
LINE 2: ALTER TABLE public.test123 ADD CONSTRAINT test123_pkey PRIMA...
        ^