### PR TITLE
Proposed solution for issue #37

### DIFF
--- a/column.go
+++ b/column.go
@@ -26,7 +26,7 @@ var (
 func initColumnSqlTemplate() *template.Template {
 	sql := `
 SELECT table_schema
-    , {{if eq $.DbSchema "*" }}table_schema || '.' || {{end}}table_name || '.' || column_name  AS compare_name
+    ,  {{if eq $.DbSchema "*" }}table_schema || '.' || {{end}}table_name || '.' ||lpad(cast (ordinal_position as varchar), 5, '0')|| column_name AS compare_name
 	, table_name
     , column_name
     , data_type


### PR DESCRIPTION

to solve this issue I had to to replace the following line in column.go
, {{if eq $.DbSchema "*" }}table_schema || '.' || {{end}}table_name || '.' || column_name AS compare_name
by

, {{if eq $.DbSchema "*" }}table_schema || '.' || {{end}}table_name || '.' ||lpad(cast (ordinal_position as varchar), 5, '0')|| column_name AS compare_name

this would add up the cardinal position of the column in the sort criteria compare_name leading to correct order